### PR TITLE
Topic id refactor

### DIFF
--- a/assets/js/user_socket.js
+++ b/assets/js/user_socket.js
@@ -57,13 +57,19 @@ socket.connect()
 // Now that you are connected, you can join channels with a topic.
 // Let's assume you have a channel with a topic named `room` and the
 // subtopic is its id - in this case 42:
-let channel = socket.channel("comments:1", {})
-channel.join()
-  .receive("ok", resp => { console.log("Joined successfully", resp) })
-  .receive("error", resp => { console.log("Unable to join", resp) })
 
-document.querySelector('button').addEventListener('click', function() {
-  channel.push('ping', {hi: 'someone!'})
-})
+// refactor per V131
+const createSocket = (topidId) => {
+  let channel = socket.channel(`comments:${topidId}`, {})
+  channel.join()
+    .receive("ok", resp => { console.log("Joined successfully", resp) })
+    .receive("error", resp => { console.log("Unable to join", resp) })
 
-export default socket
+  document.querySelector('button').addEventListener('click', () => {
+    const content = document.querySelector('textarea').value;
+
+    channel.push('comment:add', {content: content});
+  });
+}
+
+window.createSocket = createSocket;

--- a/lib/discuss/comment.ex
+++ b/lib/discuss/comment.ex
@@ -2,6 +2,8 @@ defmodule Discuss.Comment do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @derive {Jason.Encoder, only: [:content]}
+
   schema "comments" do
     field :content, :string
     belongs_to :user, Discuss.User

--- a/lib/discuss_web.ex
+++ b/lib/discuss_web.ex
@@ -75,6 +75,7 @@ defmodule DiscussWeb do
   def channel do
     quote do
       use Phoenix.Channel
+      alias Discuss.Repo
       import DiscussWeb.Gettext
     end
   end

--- a/lib/discuss_web/channels/comments_channel.ex
+++ b/lib/discuss_web/channels/comments_channel.ex
@@ -10,10 +10,13 @@ defmodule DiscussWeb.CommentsChannel do
   def join("comments:" <> topic_id, payload, socket) do
     if authorized?(payload) do
       topic_id = String.to_integer(topic_id)
-      topic = Repo.get(Topic, topic_id)
-      # IO.puts("+++++++++ topic")
-      # IO.inspect(topic)
-      {:ok, %{}, assign(socket, :topic, topic)}
+      topic = 
+        Topic
+        |> Repo.get(topic_id)
+        |> Repo.preload(:comments)
+      IO.puts("+++++++++ topic")
+      IO.inspect(topic)
+      {:ok, %{comments: topic.comments}, assign(socket, :topic, topic)}
     else
       {:error, %{reason: "unauthorized"}}
     end

--- a/lib/discuss_web/channels/comments_channel.ex
+++ b/lib/discuss_web/channels/comments_channel.ex
@@ -1,25 +1,41 @@
 defmodule DiscussWeb.CommentsChannel do
   use DiscussWeb, :channel
 
+  import Ecto
+
+  alias Phoenix.Socket.Serializer
+  alias Discuss.{Topic, Comment}
+
   @impl true
-  def join(name, payload, socket) do
+  def join("comments:" <> topic_id, payload, socket) do
     if authorized?(payload) do
-      # IO.puts("++++++ name")
-      # IO.inspect(name)
-      {:ok, %{hey: "there"}, socket}
+      topic_id = String.to_integer(topic_id)
+      topic = Repo.get(Topic, topic_id)
+      # IO.puts("+++++++++ topic")
+      # IO.inspect(topic)
+      {:ok, %{}, assign(socket, :topic, topic)}
     else
       {:error, %{reason: "unauthorized"}}
     end
   end
 
-  # custom handle_in
-  # def handle_in(name, message, socket) do
-  #   IO.puts("+++++++ name")
-  #   IO.puts(name)
-  #   IO.inspect(message)
+  # V134 handle_in for adding new comment ('comment:add')
+  def handle_in("comment:add", %{"content" => content}, socket) do
+    topic = socket.assigns.topic
+ 
+    changeset = topic
+    |> build_assoc(:comments)
+    |> Comment.changeset(%{content: content})
 
-  #   {:reply, :ok, socket}
-  # end
+    case Repo.insert(changeset) do
+      {:ok, comment} ->
+        {:reply, :ok, socket}
+      {:error, _reason} ->
+        {:reply, {:error, %{errors: changeset}}, socket}
+    end
+
+    # {:reply, {:ok, content}, socket}
+  end
 
   # Channels can be used in a request/response fashion
   # by sending replies to requests from the client

--- a/lib/discuss_web/templates/topic/show.html.heex
+++ b/lib/discuss_web/templates/topic/show.html.heex
@@ -1,2 +1,12 @@
-<%= @topic.title %>
-<button>Ping!</button>
+<h5><%= @topic.title %></h5>
+
+<div class="input-field">
+    <textarea class="materialize-textarea"></textarea>
+    <button class="btn">Add Comment</button>
+</div>
+
+<script>
+    document.addEventListener("DOMContentLoaded", function() {
+        window.createSocket(<%= @topic.id %>)
+    });
+</script>


### PR DESCRIPTION
Completed the process of sending the topic id back to the browser.  Captured the value in the _join_ function, converted it to a string, and fetched the record for the topic from the database.  Preloaded any existing comments.  Used Jason.Encoder in the comments model file to convert the list of comments to an array in JSON format returned to the browser.