### PR TITLE
Auth token

### DIFF
--- a/assets/js/user_socket.js
+++ b/assets/js/user_socket.js
@@ -7,7 +7,7 @@ import {Socket} from "phoenix"
 // And connect to the path in "lib/discuss_web/endpoint.ex". We pass the
 // token for authentication. Read below how it should be used.
 let socket = new Socket("/socket", {params: {token: window.userToken}})
-// console.log("socket:", socket)
+console.log("socket:", socket)
 
 // When you connect, you'll often need to authenticate the client.
 // For example, imagine you have an authentication plug, `MyAuth`,

--- a/assets/js/user_socket.js
+++ b/assets/js/user_socket.js
@@ -3,7 +3,7 @@
 
 // Bring in Phoenix channels client library:
 import {Socket} from "phoenix"
-
+console.log("+++++++++ in user_socket.js")
 // And connect to the path in "lib/discuss_web/endpoint.ex". We pass the
 // token for authentication. Read below how it should be used.
 let socket = new Socket("/socket", {params: {token: window.userToken}})

--- a/lib/discuss_web/channels/comments_channel.ex
+++ b/lib/discuss_web/channels/comments_channel.ex
@@ -3,7 +3,7 @@ defmodule DiscussWeb.CommentsChannel do
 
   import Ecto
 
-  alias Phoenix.Socket.Serializer
+  # alias Phoenix.Socket.Serializer
   alias Discuss.{Topic, Comment}
 
   @impl true

--- a/lib/discuss_web/channels/user_socket.ex
+++ b/lib/discuss_web/channels/user_socket.ex
@@ -22,14 +22,16 @@ defmodule DiscussWeb.UserSocket do
   # See `Phoenix.Token` documentation for examples in
   # performing token verification on connect.
   @impl true
-  def connect(%{"token" => token}, socket, _connect_info) do
-    IO.puts("+++++++ token")
+  def connect(%{"token" => token} = conn, socket, _connect_info) do
+    IO.puts("+++++++ UserSocket token")
     IO.inspect(token)
+    IO.inspect(conn)
     case Phoenix.Token.verify(socket, "user socket", token, max_age: 1_209_600) do
       {:ok, user_id} ->
         {:ok, assign(socket, :user, user_id)}
       {:error, reason} ->
-        :error
+        IO.puts("****** connect just returning socket")
+        {:ok, socket}
     end
   end
 

--- a/lib/discuss_web/channels/user_socket.ex
+++ b/lib/discuss_web/channels/user_socket.ex
@@ -22,8 +22,15 @@ defmodule DiscussWeb.UserSocket do
   # See `Phoenix.Token` documentation for examples in
   # performing token verification on connect.
   @impl true
-  def connect(_params, socket, _connect_info) do
-    {:ok, socket}
+  def connect(%{"token" => token}, socket, _connect_info) do
+    IO.puts("+++++++ token")
+    IO.inspect(token)
+    case Phoenix.Token.verify(socket, "user socket", token, max_age: 1_209_600) do
+      {:ok, user_id} ->
+        {:ok, assign(socket, :user, user_id)}
+      {:error, reason} ->
+        :error
+    end
   end
 
   # Socket id's are topics that allow you to identify all sockets for a given user:

--- a/lib/discuss_web/controllers/auth_controller.ex
+++ b/lib/discuss_web/controllers/auth_controller.ex
@@ -13,6 +13,9 @@ defmodule DiscussWeb.AuthController do
     end
 
     defp signin(conn, changeset) do
+        Map.drop([:user])
+        IO.puts("++++++++ in signin, conn.assigns")
+        IO.inspect(conn.assigns)
         case insert_or_update_user(changeset) do
             {:ok, user} ->
                 conn

--- a/lib/discuss_web/controllers/auth_controller.ex
+++ b/lib/discuss_web/controllers/auth_controller.ex
@@ -13,7 +13,6 @@ defmodule DiscussWeb.AuthController do
     end
 
     defp signin(conn, changeset) do
-        Map.drop([:user])
         IO.puts("++++++++ in signin, conn.assigns")
         IO.inspect(conn.assigns)
         case insert_or_update_user(changeset) do

--- a/lib/discuss_web/controllers/plugs/set_user.ex
+++ b/lib/discuss_web/controllers/plugs/set_user.ex
@@ -10,11 +10,14 @@ defmodule Discuss.Plugs.SetUser do
 
     def call(conn, _opts) do
         user_id = get_session(conn, :user_id)
-        IO.puts("+++++++ SetUser user_id")
-        IO.inspect(user_id)
+        # x = is_nil(uid)
+        # user_id = 1
+        IO.puts("+++++++ SetUser conn is_nil")
+        IO.inspect(is_nil(user_id))
 
         cond do
             user = user_id && Repo.get(User, user_id) ->
+                IO.inspect(user)
                 assign(conn, :user, user)
             true ->
                 assign(conn, :user, nil)

--- a/lib/discuss_web/controllers/plugs/set_user.ex
+++ b/lib/discuss_web/controllers/plugs/set_user.ex
@@ -10,6 +10,8 @@ defmodule Discuss.Plugs.SetUser do
 
     def call(conn, _opts) do
         user_id = get_session(conn, :user_id)
+        IO.puts("+++++++ SetUser user_id")
+        IO.inspect(user_id)
 
         cond do
             user = user_id && Repo.get(User, user_id) ->

--- a/lib/discuss_web/controllers/topic_controller.ex
+++ b/lib/discuss_web/controllers/topic_controller.ex
@@ -7,8 +7,8 @@ defmodule DiscussWeb.TopicController do
   plug :check_topic_owner when action in [:update, :edit, :delete]
 
   def index(conn, _params) do
-    # IO.puts("**** conn.assigns ******")
-    # IO.inspect(conn.assigns)
+    IO.puts("**** index route conn.assigns ******")
+    IO.inspect(conn.assigns)
     topics = Repo.all(Topic)
     # IO.inspect(topics)
     render conn, "index.html", topics: topics

--- a/lib/discuss_web/router.ex
+++ b/lib/discuss_web/router.ex
@@ -39,12 +39,16 @@ defmodule DiscussWeb.Router do
 
   # plug for getting user token
   defp put_user_token(conn, _) do
-    # IO.puts("+++++ conn.assigns.user")
-    # IO.inspect(conn.assigns.user.id)
-    if conn.assigns.user do
+    IO.puts("+++++ put_user_token conn.assigns")
+    IO.inspect(conn.assigns)
+    # if not is_nil(conn.assigns.user) do
+    if not is_nil(conn.assigns.user) do
       token = Phoenix.Token.sign(conn, "user socket", conn.assigns.user.id)
+      IO.puts("******* after Token.sign")
+      IO.inspect(token)
       assign(conn, :user_token, token)
     else
+      IO.puts("+++ PASSING CONN NO TOKEN")
       conn
     end
   end

--- a/lib/discuss_web/router.ex
+++ b/lib/discuss_web/router.ex
@@ -10,6 +10,7 @@ defmodule DiscussWeb.Router do
     plug :protect_from_forgery
     plug :put_secure_browser_headers
     plug Discuss.Plugs.SetUser
+    plug :put_user_token
   end
 
   pipeline :api do
@@ -34,6 +35,18 @@ defmodule DiscussWeb.Router do
     get "/signout", AuthController, :signout
     get "/:provider", AuthController, :request
     get "/:provider/callback", AuthController, :callback
+  end
+
+  # plug for getting user token
+  defp put_user_token(conn, _) do
+    # IO.puts("+++++ conn.assigns.user")
+    # IO.inspect(conn.assigns.user.id)
+    if conn.assigns.user do
+      token = Phoenix.Token.sign(conn, "user socket", conn.assigns.user.id)
+      assign(conn, :user_token, token)
+    else
+      conn
+    end
   end
 
   # Other scopes may use custom stacks.

--- a/lib/discuss_web/templates/layout/root.html.heex
+++ b/lib/discuss_web/templates/layout/root.html.heex
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
     <script defer phx-track-static type="text/javascript" src={Routes.static_path(@conn, "/assets/app.js")}></script>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <script>window.userToken = "<%= assigns[:user_token] %>";</script>
   </head>
   <body>
     <header>

--- a/lib/discuss_web/templates/topic/index.html.heex
+++ b/lib/discuss_web/templates/topic/index.html.heex
@@ -5,7 +5,7 @@
         <li class="collection-item">
             <%= link topic.title, to: Routes.topic_path(@conn, :show, topic) %>
 
-            <%= if @conn.assigns.user.id == topic.user_id do %>
+            <%= if @conn.assigns.user && @conn.assigns.user.id == topic.user_id do %>
                 <div class="right">
                     <%= link "Edit", to: Routes.topic_path(@conn, :edit, topic) %>
                     <%= link "Delete", to: Routes.topic_path(@conn, :delete, topic), method: :delete %>


### PR DESCRIPTION
Correct issue with the 'nil' value for the conn.assigns.user, which cause crashes.  Modified _put_user_token_ plug to use 'is_nil' as the condition for adding a token to 'conn'.  Also modified the 'connect' function in 'user_socket.ex' to return {:ok, socket} if there is no token (user not logged in), fixing another crash.  